### PR TITLE
Standardize the iso860 for dates; fix the passing of event parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,14 @@ api.reset_anomalous_users([12345, 23456])
 api.track_events(event, force_anomalous_override: true)
 ```
 
-API based data export.  Note well that Leanplum officially recommends use of the automated S3 export instead of API based export.  According to a Leanplum engineer these two data export methodologies are completely independent data paths and in our experience we have found API based data export to be missing 10-15% of the data that is eventually returned by the automated export.
+API based data export:
 ```ruby
 api = LeanplumApi::API.new
 job_id = api.export_data(start_time, end_time)
 response = wait_for_job(job_id)
 ```
+
+Note well that Leanplum officially recommends use of the automated S3 export instead of API based export.  According to a Leanplum engineer these two data export methodologies are completely independent data paths and in our experience we have found API based data export to be missing 10-15% of the data that is eventually returned by the automated export.
 
 ## Specs
 

--- a/README.md
+++ b/README.md
@@ -57,19 +57,19 @@ attribute_hash = {
   first_name: 'Mike',
   last_name: 'Jones',
   gender: 'm',
-  birthday: Date.today, # Dates and times in user attributes will be formatted as strings; Leanplum doesn't support date or time types
+  birthday: Date.today, # Dates/times only sort of supported in user attributes
   email: 'still_tippin@test.com'
 }
 api.set_user_attributes(attribute_hash)
 
-# You must also provide the :event property for event tracking
+# You must also provide the :event property for event tracking.
+# You can optionally provide a :time property; if it is not set Leanplum will timestamp the event "now".
+# All other key/values besides :user_id, :device_id, :event, and :time will be sent as event params/properties.
 event = {
   user_id: 12345,
   event: 'purchase',
   time: Time.now.utc, # Event timestamps will be converted to epoch seconds by the gem.
-  params: {
-    'some_event_property' => 'boss_hog_on_candy'
-  }
+  some_event_property: 'boss_hog_on_candy'
 }
 api.track_events(event)
 
@@ -83,7 +83,7 @@ api.reset_anomalous_users([12345, 23456])
 api.track_events(event, force_anomalous_override: true)
 ```
 
-Data export:
+API based data export.  Note well that Leanplum officially recommends use of the automated S3 export instead of API based export.  According to a Leanplum engineer these two data export methodologies are completely independent data paths and in our experience we have found API based data export to be missing 10-15% of the data that is eventually returned by the automated export.
 ```ruby
 api = LeanplumApi::API.new
 job_id = api.export_data(start_time, end_time)
@@ -92,10 +92,10 @@ response = wait_for_job(job_id)
 
 ## Specs
 
-To run specs, you must set the LEANPLUM_PRODUCTION_KEY, LEANPLUM_APP_ID, LEANPLUM_CONTENT_READ_ONLY_KEY, LEANPLUM_DEVELOPMENT_KEY, and LEANPLUM_DATA_EXPORT_KEY environment variables (preferably to some development only keys) to something and then run rspec.
+To run specs, you must set the `LEANPLUM_PRODUCTION_KEY`, `LEANPLUM_APP_ID`, `LEANPLUM_CONTENT_READ_ONLY_KEY`, `LEANPLUM_DEVELOPMENT_KEY`, and `LEANPLUM_DATA_EXPORT_KEY` environment variables (preferably to some development only keys) to something and then run rspec.
 Because of the nature of VCR/Webmock, you can set them to anything (including invalid keys) as long as you are not changing anything substantive or writing new specs.  If you want to make substantive changes/add new specs, VCR will need to be able to generate fixture data so you will need to use a real set of Leanplum keys.
 
-> BE AWARE THAT IF YOU WRITE A NEW SPEC OR DELETE A VCR FILE, IT'S POSSIBLE THAT REAL DATA WILL BE WRITTEN TO THE LEANPLUM_APP_ID YOU CONFIGURE!  Certainly a real request will be made to rebuild the VCR file, and while specs run with ```devMode=true```, it's usually a good idea to create a fake app for testing/running specs against.
+> BE AWARE THAT IF YOU WRITE A NEW SPEC OR DELETE A VCR FILE, IT'S POSSIBLE THAT REAL DATA WILL BE WRITTEN TO THE `LEANPLUM_APP_ID` YOU CONFIGURE!  Certainly a real request will be made to rebuild the VCR file, and while specs run with ```devMode=true```, it's usually a good idea to create a fake app for testing/running specs against.
 
 ```bash
 export LEANPLUM_PRODUCTION_KEY=dev_somethingsomeg123456
@@ -117,4 +117,4 @@ export LEANPLUM_API_DEBUG=true
 bundle exec rails whatever
 ```
 
-You can also configure "developer mode".  This will use the "devMode=true" parameter on all requests, which sends them to a separate queue (and probably means actions logged as development tests don't count towards your bill).
+You can also configure "developer mode".  This will use the "devMode=true" parameter on some requests, which seems to sends them to a separate queue which might not count towards Leanplum's usage billing.

--- a/lib/leanplum_api/api.rb
+++ b/lib/leanplum_api/api.rb
@@ -199,17 +199,17 @@ module LeanplumApi
     # Events have a :user_id or :device id, a name (:event) and an optional time (:time)
     def build_event_attributes_hash(event_hash)
       event_hash = HashWithIndifferentAccess.new(event_hash)
-      fail "Event name or timestamp not provided in #{event_hash}" unless event_hash[:event]
+      event_name = event_hash.delete(:event)
+      fail "Event name or timestamp not provided in #{event_hash}" unless event_name
 
       # TODO: Putting event params at the :params key is deprecated and should be removed in a 2.0 release
       event_hash.merge!(event_hash.delete(:params)) if event_hash[:params]
 
-      time_hash = event_hash[:time] ? { 'time' => event_hash[:time].strftime('%s') } : {}
-      time_hash.merge!('action' => 'track', 'event' => event_hash[:event])
-      time_hash.merge!(extract_user_id_or_device_id_hash!(event_hash))
-      event_params = event_hash.reject { |k,v| k.to_s =~ /^(event|time)$/ }
+      event = { 'action' => 'track', 'event' => event_name }.merge(extract_user_id_or_device_id_hash!(event_hash))
+      time = event_hash.delete(:time)
+      event.merge!('time' => time.strftime('%s')) if time
 
-      event_params.keys.size > 0 ? time_hash.merge('params' => event_params ) : time_hash
+      event_hash.keys.size > 0 ? event.merge('params' => event_hash ) : event
     end
   end
 end

--- a/lib/leanplum_api/api.rb
+++ b/lib/leanplum_api/api.rb
@@ -143,8 +143,8 @@ module LeanplumApi
       @http.get(action: 'getVars', userId: user_id).body['response'].first['vars']
     end
 
-    # If you pass old events OR users with old date attributes (i.e. create_date for an old users), leanplum will mark them 'anomalous'
-    # and exclude them from your data set.
+    # If you pass old events OR users with old date attributes (i.e. create_date for an old users), leanplum will mark
+    # them 'anomalous' and exclude them from your data set.
     # Calling this method after you pass old events will fix that for all events for the specified user_id
     # For some reason this API feature requires the developer key
     def reset_anomalous_users(user_ids)
@@ -185,15 +185,10 @@ module LeanplumApi
 
       # As of 2015-10 Leanplum supports ISO8601 date strings as user attributes. Support for times is as yet unavailable.
       user_hash.each do |k,v|
-        if v.is_a?(Date)
-          user_hash[k] = v.iso8601
-        elsif v.is_a?(Time) || v.is_a?(DateTime)
-          user_hash[k] = v.strftime('%Y-%m-%d %H:%M:%S')
-        end
+        user_hash[k] = v.iso8601 if v.is_a?(Date) || v.is_a?(Time) || v.is_a?(DateTime)
       end
 
-      user_id = extract_user_id_or_device_id_hash!(user_hash)
-      user_id.merge('action' => action, 'userAttributes' => user_hash)
+      extract_user_id_or_device_id_hash!(user_hash).merge('action' => action, 'userAttributes' => user_hash)
     end
 
     # Events have a :user_id or :device id, a name (:event) and an optional time (:time)
@@ -201,9 +196,6 @@ module LeanplumApi
       event_hash = HashWithIndifferentAccess.new(event_hash)
       event_name = event_hash.delete(:event)
       fail "Event name or timestamp not provided in #{event_hash}" unless event_name
-
-      # TODO: Putting event params at the :params key is deprecated and should be removed in a 2.0 release
-      event_hash.merge!(event_hash.delete(:params)) if event_hash[:params]
 
       event = { 'action' => 'track', 'event' => event_name }.merge(extract_user_id_or_device_id_hash!(event_hash))
       time = event_hash.delete(:time)

--- a/lib/leanplum_api/version.rb
+++ b/lib/leanplum_api/version.rb
@@ -1,4 +1,3 @@
 module LeanplumApi
-  # Remove deprecated track_events :params key handling when releasing 2.0.0
-  VERSION = '1.3.8'
+  VERSION = '1.4.0'
 end

--- a/lib/leanplum_api/version.rb
+++ b/lib/leanplum_api/version.rb
@@ -1,3 +1,4 @@
 module LeanplumApi
-  VERSION = '1.3.7'
+  # Remove deprecated track_events :params key handling when releasing 2.0.0
+  VERSION = '1.3.8'
 end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -19,13 +19,13 @@ describe LeanplumApi::API do
       expect(api.send(:build_user_attributes_hash, users.first)).to eq({
         'userId' => 123456,
         'action' => 'setUserAttributes',
-        'userAttributes' => {
+        'userAttributes' => HashWithIndifferentAccess.new(
           first_name: 'Mike',
           last_name: 'Jones',
           gender: 'm',
           email: 'still_tippin@test.com',
           create_date: '2010-01-01'
-        }
+        )
       })
     end
 
@@ -84,26 +84,37 @@ describe LeanplumApi::API do
           user_id: 12345,
           event: 'purchase',
           time: Time.now.utc,
-          params: {
-            'some_timestamp' => '2015-05-01 01:02:03'
-          }
+          'some_timestamp' => '2015-05-01 01:02:03'
         },
         {
           user_id: 54321,
           event: 'purchase_page_view',
-          time: Time.now.utc - 10.minutes,
+          time: Time.now.utc - 10.minutes
         }
       ]
     end
 
-    it 'build_event_attributes_hash' do
-      expect(api.send(:build_event_attributes_hash, events.first)).to eq({
-        'userId' => 12345,
-        'time' => Time.now.utc.strftime('%s'),
-        'action' => 'track',
-        'event' => 'purchase',
-        'params' => { params: { 'some_timestamp'=>'2015-05-01 01:02:03' } }
-      })
+    context '#build_event_attributes_hash' do
+      it 'builds the events from a deprecated format' do
+        expect(api.send(:build_event_attributes_hash, events.first)).to eq({
+          'userId' => 12345,
+          'time' => Time.now.utc.strftime('%s'),
+          'action' => 'track',
+          'event' => 'purchase',
+          'params' => { 'some_timestamp'=>'2015-05-01 01:02:03' }
+        })
+      end
+
+      it 'builds the events from a deprecated format' do
+        deprecated_format_event = events.last.merge(params: { 'some_timestamp' => '2015-05-01 01:02:03' })
+        expect(api.send(:build_event_attributes_hash, events.first)).to eq({
+          'userId' => 12345,
+          'time' => Time.now.utc.strftime('%s'),
+          'action' => 'track',
+          'event' => 'purchase',
+          'params' => { 'some_timestamp'=>'2015-05-01 01:02:03' }
+        })
+      end
     end
 
     context 'without user attributes' do

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -109,11 +109,6 @@ describe LeanplumApi::API do
       it 'builds the events format' do
         expect(api.send(:build_event_attributes_hash, events.first)).to eq(event_hash)
       end
-
-      it 'builds the events from a deprecated format' do
-        deprecated_event = events.first.reject { |k,v| k == 'some_timestamp' }.merge(params: { some_timestamp: timestamp })
-        expect(api.send(:build_event_attributes_hash, deprecated_event)).to eq(event_hash)
-      end
     end
 
     context 'without user attributes' do

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -78,13 +78,14 @@ describe LeanplumApi::API do
   end
 
   context 'events' do
+    let(:timestamp) { '2015-05-01 01:02:03' }
     let(:events) do
       [
         {
           user_id: 12345,
           event: 'purchase',
           time: Time.now.utc,
-          'some_timestamp' => '2015-05-01 01:02:03'
+          some_timestamp: timestamp
         },
         {
           user_id: 54321,
@@ -95,25 +96,23 @@ describe LeanplumApi::API do
     end
 
     context '#build_event_attributes_hash' do
-      it 'builds the events from a deprecated format' do
-        expect(api.send(:build_event_attributes_hash, events.first)).to eq({
+      let(:event_hash) do
+        {
           'userId' => 12345,
           'time' => Time.now.utc.strftime('%s'),
           'action' => 'track',
           'event' => 'purchase',
-          'params' => { 'some_timestamp'=>'2015-05-01 01:02:03' }
-        })
+          'params' => { 'some_timestamp' => timestamp }
+        }
+      end
+
+      it 'builds the events format' do
+        expect(api.send(:build_event_attributes_hash, events.first)).to eq(event_hash)
       end
 
       it 'builds the events from a deprecated format' do
-        deprecated_format_event = events.last.merge(params: { 'some_timestamp' => '2015-05-01 01:02:03' })
-        expect(api.send(:build_event_attributes_hash, events.first)).to eq({
-          'userId' => 12345,
-          'time' => Time.now.utc.strftime('%s'),
-          'action' => 'track',
-          'event' => 'purchase',
-          'params' => { 'some_timestamp'=>'2015-05-01 01:02:03' }
-        })
+        deprecated_event = events.first.reject { |k,v| k == 'some_timestamp' }.merge(params: { some_timestamp: timestamp })
+        expect(api.send(:build_event_attributes_hash, deprecated_event)).to eq(event_hash)
       end
     end
 

--- a/spec/fixtures/vcr/track_events.yml
+++ b/spec/fixtures/vcr/track_events.yml
@@ -5,8 +5,8 @@ http_interactions:
     uri: https://www.leanplum.com/api?action=multi&apiVersion=1.0.6&appId=<LEANPLUM_APP_ID>&clientKey=<LEANPLUM_PRODUCTION_KEY>&devMode=false&time=1439337600
     body:
       encoding: UTF-8
-      string: '{"data":[{"userId":12345,"time":"1439337600","action":"track","event":"purchase","params":{"params":{"some_timestamp":"2015-05-01
-        01:02:03"}}},{"userId":54321,"time":"1439337000","action":"track","event":"purchase_page_view"}]}'
+      string: '{"data":[{"time":"1439337600","action":"track","event":"purchase","userId":12345,"params":{"some_timestamp":"2015-05-01
+        01:02:03"}},{"time":"1439337000","action":"track","event":"purchase_page_view","userId":54321}]}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -40,6 +40,6 @@ http_interactions:
       string: '{"response":[{"isOffline":true,"success":true,"warning":{"message":"Anomaly
         detected: time skew. User will be excluded from analytics."}},{"success":true,"warning":{"message":"Anomaly
         detected: time skew. User will be excluded from analytics."}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 12 Aug 2015 00:00:00 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/track_events.yml
+++ b/spec/fixtures/vcr/track_events.yml
@@ -5,8 +5,8 @@ http_interactions:
     uri: https://www.leanplum.com/api?action=multi&apiVersion=1.0.6&appId=<LEANPLUM_APP_ID>&clientKey=<LEANPLUM_PRODUCTION_KEY>&devMode=false&time=1439337600
     body:
       encoding: UTF-8
-      string: '{"data":[{"time":"1439337600","action":"track","event":"purchase","userId":12345,"params":{"some_timestamp":"2015-05-01
-        01:02:03"}},{"time":"1439337000","action":"track","event":"purchase_page_view","userId":54321}]}'
+      string: '{"data":[{"action":"track","event":"purchase","userId":12345,"time":"1439337600","params":{"some_timestamp":"2015-05-01
+        01:02:03"}},{"action":"track","event":"purchase_page_view","userId":54321,"time":"1439337000"}]}'
     headers:
       User-Agent:
       - Faraday v0.9.2

--- a/spec/fixtures/vcr/track_events_and_attributes.yml
+++ b/spec/fixtures/vcr/track_events_and_attributes.yml
@@ -5,8 +5,8 @@ http_interactions:
     uri: https://www.leanplum.com/api?action=multi&apiVersion=1.0.6&appId=<LEANPLUM_APP_ID>&clientKey=<LEANPLUM_PRODUCTION_KEY>&devMode=false&time=1439337600
     body:
       encoding: UTF-8
-      string: '{"data":[{"userId":123456,"action":"setUserAttributes","userAttributes":{"first_name":"Mike","last_name":"Jones","gender":"m","email":"still_tippin@test.com","create_date":"2010-01-01"}},{"time":"1439337600","action":"track","event":"purchase","userId":12345,"params":{"some_timestamp":"2015-05-01
-        01:02:03"}},{"time":"1439337000","action":"track","event":"purchase_page_view","userId":54321}]}'
+      string: '{"data":[{"userId":123456,"action":"setUserAttributes","userAttributes":{"first_name":"Mike","last_name":"Jones","gender":"m","email":"still_tippin@test.com","create_date":"2010-01-01"}},{"action":"track","event":"purchase","userId":12345,"time":"1439337600","params":{"some_timestamp":"2015-05-01
+        01:02:03"}},{"action":"track","event":"purchase_page_view","userId":54321,"time":"1439337000"}]}'
     headers:
       User-Agent:
       - Faraday v0.9.2

--- a/spec/fixtures/vcr/track_events_and_attributes.yml
+++ b/spec/fixtures/vcr/track_events_and_attributes.yml
@@ -5,8 +5,8 @@ http_interactions:
     uri: https://www.leanplum.com/api?action=multi&apiVersion=1.0.6&appId=<LEANPLUM_APP_ID>&clientKey=<LEANPLUM_PRODUCTION_KEY>&devMode=false&time=1439337600
     body:
       encoding: UTF-8
-      string: '{"data":[{"userId":123456,"action":"setUserAttributes","userAttributes":{"first_name":"Mike","last_name":"Jones","gender":"m","email":"still_tippin@test.com","create_date":"2010-01-01"}},{"userId":12345,"time":"1439337600","action":"track","event":"purchase","params":{"params":{"some_timestamp":"2015-05-01
-        01:02:03"}}},{"userId":54321,"time":"1439337000","action":"track","event":"purchase_page_view"}]}'
+      string: '{"data":[{"userId":123456,"action":"setUserAttributes","userAttributes":{"first_name":"Mike","last_name":"Jones","gender":"m","email":"still_tippin@test.com","create_date":"2010-01-01"}},{"time":"1439337600","action":"track","event":"purchase","userId":12345,"params":{"some_timestamp":"2015-05-01
+        01:02:03"}},{"time":"1439337000","action":"track","event":"purchase_page_view","userId":54321}]}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -41,6 +41,6 @@ http_interactions:
         detected: time skew. User will be excluded from analytics."}},{"success":true,"warning":{"message":"Anomaly
         detected: time skew. User will be excluded from analytics."}},{"success":true,"warning":{"message":"Anomaly
         detected: time skew. User will be excluded from analytics."}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 12 Aug 2015 00:00:00 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/track_events_anomaly_overrider.yml
+++ b/spec/fixtures/vcr/track_events_anomaly_overrider.yml
@@ -5,8 +5,8 @@ http_interactions:
     uri: https://www.leanplum.com/api?action=multi&apiVersion=1.0.6&appId=<LEANPLUM_APP_ID>&clientKey=<LEANPLUM_PRODUCTION_KEY>&devMode=false&time=1439337600
     body:
       encoding: UTF-8
-      string: '{"data":[{"time":"1439337600","action":"track","event":"purchase","userId":12345,"params":{"some_timestamp":"2015-05-01
-        01:02:03"}},{"time":"1439337000","action":"track","event":"purchase_page_view","userId":54321}]}'
+      string: '{"data":[{"action":"track","event":"purchase","userId":12345,"time":"1439337600","params":{"some_timestamp":"2015-05-01
+        01:02:03"}},{"action":"track","event":"purchase_page_view","userId":54321,"time":"1439337000"}]}'
     headers:
       User-Agent:
       - Faraday v0.9.2

--- a/spec/fixtures/vcr/track_events_anomaly_overrider.yml
+++ b/spec/fixtures/vcr/track_events_anomaly_overrider.yml
@@ -5,8 +5,8 @@ http_interactions:
     uri: https://www.leanplum.com/api?action=multi&apiVersion=1.0.6&appId=<LEANPLUM_APP_ID>&clientKey=<LEANPLUM_PRODUCTION_KEY>&devMode=false&time=1439337600
     body:
       encoding: UTF-8
-      string: '{"data":[{"userId":12345,"time":"1439337600","action":"track","event":"purchase","params":{"params":{"some_timestamp":"2015-05-01
-        01:02:03"}}},{"userId":54321,"time":"1439337000","action":"track","event":"purchase_page_view"}]}'
+      string: '{"data":[{"time":"1439337600","action":"track","event":"purchase","userId":12345,"params":{"some_timestamp":"2015-05-01
+        01:02:03"}},{"time":"1439337000","action":"track","event":"purchase_page_view","userId":54321}]}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -40,7 +40,7 @@ http_interactions:
       string: '{"response":[{"isOffline":true,"success":true,"warning":{"message":"Anomaly
         detected: time skew. User will be excluded from analytics."}},{"success":true,"warning":{"message":"Anomaly
         detected: time skew. User will be excluded from analytics."}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 12 Aug 2015 00:00:00 GMT
 - request:
     method: post
@@ -81,6 +81,6 @@ http_interactions:
       string: '{"response":[{"success":true,"warning":{"message":"Anomaly detected:
         time skew. User will be excluded from analytics."}},{"success":true,"warning":{"message":"Anomaly
         detected: time skew. User will be excluded from analytics."}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 12 Aug 2015 00:00:00 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
All user attribute dates should be encoded as ISO8601 string.

Also there was an unrelated bug (not related to any of our use cases) whereby event params ended up with an incorrect hash - instead of `params: { some_param: 'value' }` we were building `params: { params:  { some_param: 'value' } }`

@venders @PalSzabolcs 