### PR TITLE
Add user_attributes and user_events methods

### DIFF
--- a/lib/leanplum_api/api.rb
+++ b/lib/leanplum_api/api.rb
@@ -115,8 +115,16 @@ module LeanplumApi
       get_export_results(job_id)
     end
 
+    def user_attributes(user_id)
+      export_user(user_id)['userAttributes']
+    end
+
+    def user_events(user_id)
+      export_user(user_id)['events']
+    end
+
     def export_user(user_id)
-      data_export_connection.get(action: 'exportUser', userId: user_id).body['response'].first['userAttributes']
+      data_export_connection.get(action: 'exportUser', userId: user_id).body['response'].first
     end
 
     def get_ab_tests(only_recent = false)

--- a/lib/leanplum_api/connections/production.rb
+++ b/lib/leanplum_api/connections/production.rb
@@ -41,6 +41,7 @@ module LeanplumApi::Connection
 
       @connection ||= Faraday.new(options) do |connection|
         connection.request :leanplum_response_validation
+        connection.request :json
 
         connection.response :logger, @logger, bodies: true if api_debug?
         connection.response :json, :content_type => /\bjson$/

--- a/lib/leanplum_api/version.rb
+++ b/lib/leanplum_api/version.rb
@@ -1,3 +1,3 @@
 module LeanplumApi
-  VERSION = '1.4.2'
+  VERSION = '2.0.0'
 end

--- a/spec/fixtures/vcr/export_user.yml
+++ b/spec/fixtures/vcr/export_user.yml
@@ -23,18 +23,18 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 04 Nov 2015 20:50:03 GMT
+      - Wed, 13 Apr 2016 02:33:35 GMT
       Server:
       - Google Frontend
       Cache-Control:
       - private
       Alt-Svc:
-      - quic=":443"; p="1"; ma=604800
+      - quic=":443"; ma=2592000; v="32,31,30,29,28,27,26,25"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"response":[{"events":{},"states":{},"success":true,"userAttributes":{"first_name":"Mike","create_date":"2010-01-01","email":"still_tippin@test.com","last_name":"Jones","gender":"m"}}]}'
+      string: '{"response":[{"created":1.43935302887E9,"events":{"purchase":{"count":4}},"states":{},"success":true,"userAttributes":{"first_name":"Mike","create_date":"2010-01-01","email":"still_tippin@test.com","last_name":"Jones","gender":"m"}}]}'
     http_version: 
   recorded_at: Wed, 12 Aug 2015 00:00:00 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/track_events.yml
+++ b/spec/fixtures/vcr/track_events.yml
@@ -5,13 +5,11 @@ http_interactions:
     uri: https://www.leanplum.com/api?action=multi&apiVersion=1.0.6&appId=<LEANPLUM_APP_ID>&clientKey=<LEANPLUM_PRODUCTION_KEY>&devMode=false&time=1439337600
     body:
       encoding: UTF-8
-      string: '{"data":[{"action":"track","event":"purchase","userId":12345,"time":"1439337600","params":{"some_timestamp":"2015-05-01
+      string: '{"data":[{"action":"track","event":"purchase","userId":123456,"time":"1439337600","params":{"some_timestamp":"2015-05-01
         01:02:03"}},{"action":"track","event":"purchase_page_view","userId":54321,"time":"1439337000"}]}'
     headers:
       User-Agent:
       - Faraday v0.9.2
-      Content-Type:
-      - application/json
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -26,20 +24,20 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 04 Nov 2015 21:50:11 GMT
+      - Wed, 13 Apr 2016 02:29:53 GMT
       Server:
       - Google Frontend
       Cache-Control:
       - private
       Alt-Svc:
-      - quic=":443"; p="1"; ma=604800
+      - quic=":443"; ma=2592000; v="32,31,30,29,28,27,26,25"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: '{"response":[{"isOffline":true,"success":true,"warning":{"message":"Anomaly
-        detected: time skew. User will be excluded from analytics."}},{"success":true,"warning":{"message":"Anomaly
+        detected: time skew. User will be excluded from analytics."}},{"isOffline":true,"success":true,"warning":{"message":"Anomaly
         detected: time skew. User will be excluded from analytics."}}]}'
-    http_version:
+    http_version: 
   recorded_at: Wed, 12 Aug 2015 00:00:00 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/track_events_and_attributes.yml
+++ b/spec/fixtures/vcr/track_events_and_attributes.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://www.leanplum.com/api?action=multi&apiVersion=1.0.6&appId=<LEANPLUM_APP_ID>&clientKey=<LEANPLUM_PRODUCTION_KEY>&devMode=false&time=1439337600
     body:
       encoding: UTF-8
-      string: '{"data":[{"userId":123456,"action":"setUserAttributes","userAttributes":{"first_name":"Mike","last_name":"Jones","gender":"m","email":"still_tippin@test.com","create_date":"2010-01-01"}},{"action":"track","event":"purchase","userId":12345,"time":"1439337600","params":{"some_timestamp":"2015-05-01
+      string: '{"data":[{"userId":123456,"action":"setUserAttributes","userAttributes":{"first_name":"Mike","last_name":"Jones","gender":"m","email":"still_tippin@test.com","create_date":"2010-01-01"}},{"action":"track","event":"purchase","userId":123456,"time":"1439337600","params":{"some_timestamp":"2015-05-01
         01:02:03"}},{"action":"track","event":"purchase_page_view","userId":54321,"time":"1439337000"}]}'
     headers:
       User-Agent:
@@ -26,21 +26,21 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 04 Nov 2015 20:50:05 GMT
+      - Wed, 13 Apr 2016 02:33:37 GMT
       Server:
       - Google Frontend
       Cache-Control:
       - private
       Alt-Svc:
-      - quic=":443"; p="1"; ma=604800
+      - quic=":443"; ma=2592000; v="32,31,30,29,28,27,26,25"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"response":[{"isOffline":true,"success":true,"warning":{"message":"Anomaly
-        detected: time skew. User will be excluded from analytics."}},{"success":true,"warning":{"message":"Anomaly
-        detected: time skew. User will be excluded from analytics."}},{"success":true,"warning":{"message":"Anomaly
+      string: '{"response":[{"success":true,"warning":{"message":"Anomaly detected:
+        time skew. User will be excluded from analytics."}},{"isOffline":true,"success":true,"warning":{"message":"Anomaly
+        detected: time skew. User will be excluded from analytics."}},{"isOffline":true,"success":true,"warning":{"message":"Anomaly
         detected: time skew. User will be excluded from analytics."}}]}'
-    http_version:
+    http_version: 
   recorded_at: Wed, 12 Aug 2015 00:00:00 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/track_events_anomaly_overrider.yml
+++ b/spec/fixtures/vcr/track_events_anomaly_overrider.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://www.leanplum.com/api?action=multi&apiVersion=1.0.6&appId=<LEANPLUM_APP_ID>&clientKey=<LEANPLUM_PRODUCTION_KEY>&devMode=false&time=1439337600
     body:
       encoding: UTF-8
-      string: '{"data":[{"action":"track","event":"purchase","userId":12345,"time":"1439337600","params":{"some_timestamp":"2015-05-01
+      string: '{"data":[{"action":"track","event":"purchase","userId":123456,"time":"1439337600","params":{"some_timestamp":"2015-05-01
         01:02:03"}},{"action":"track","event":"purchase_page_view","userId":54321,"time":"1439337000"}]}'
     headers:
       User-Agent:
@@ -26,28 +26,28 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 05 Nov 2015 07:53:30 GMT
+      - Wed, 13 Apr 2016 02:33:36 GMT
       Server:
       - Google Frontend
       Cache-Control:
       - private
       Alt-Svc:
-      - quic=":443"; p="1"; ma=604800
+      - quic=":443"; ma=2592000; v="32,31,30,29,28,27,26,25"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: '{"response":[{"isOffline":true,"success":true,"warning":{"message":"Anomaly
-        detected: time skew. User will be excluded from analytics."}},{"success":true,"warning":{"message":"Anomaly
+        detected: time skew. User will be excluded from analytics."}},{"isOffline":true,"success":true,"warning":{"message":"Anomaly
         detected: time skew. User will be excluded from analytics."}}]}'
-    http_version:
+    http_version: 
   recorded_at: Wed, 12 Aug 2015 00:00:00 GMT
 - request:
     method: post
     uri: https://www.leanplum.com/api?action=multi&apiVersion=1.0.6&appId=<LEANPLUM_APP_ID>&clientKey=<LEANPLUM_DEVELOPMENT_KEY>&devMode=false&time=1439337600
     body:
       encoding: UTF-8
-      string: '{"data":[{"action":"setUserAttributes","resetAnomalies":true,"userId":12345},{"action":"setUserAttributes","resetAnomalies":true,"userId":54321}]}'
+      string: '{"data":[{"action":"setUserAttributes","resetAnomalies":true,"userId":123456},{"action":"setUserAttributes","resetAnomalies":true,"userId":54321}]}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -67,20 +67,18 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 05 Nov 2015 07:53:30 GMT
+      - Wed, 13 Apr 2016 02:33:37 GMT
       Server:
       - Google Frontend
       Cache-Control:
       - private
       Alt-Svc:
-      - quic=":443"; p="1"; ma=604800
+      - quic=":443"; ma=2592000; v="32,31,30,29,28,27,26,25"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"response":[{"success":true,"warning":{"message":"Anomaly detected:
-        time skew. User will be excluded from analytics."}},{"success":true,"warning":{"message":"Anomaly
-        detected: time skew. User will be excluded from analytics."}}]}'
-    http_version:
+      string: '{"response":[{"success":true},{"success":true}]}'
+    http_version: 
   recorded_at: Wed, 12 Aug 2015 00:00:00 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/track_offline_events.yml
+++ b/spec/fixtures/vcr/track_offline_events.yml
@@ -5,11 +5,13 @@ http_interactions:
     uri: https://www.leanplum.com/api?action=multi&apiVersion=1.0.6&appId=<LEANPLUM_APP_ID>&clientKey=<LEANPLUM_PRODUCTION_KEY>&devMode=false&time=1439337600
     body:
       encoding: UTF-8
-      string: '{"data":[{"action":"track","event":"purchase","userId":12345,"time":"1439337600","allowOffline":true,"params":{"some_timestamp":"2015-05-01
+      string: '{"data":[{"action":"track","event":"purchase","userId":123456,"time":"1439337600","allowOffline":true,"params":{"some_timestamp":"2015-05-01
         01:02:03"}},{"action":"track","event":"purchase_page_view","userId":54321,"time":"1439337000","allowOffline":true}]}'
     headers:
       User-Agent:
       - Faraday v0.9.2
+      Content-Type:
+      - application/json
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -24,19 +26,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 28 Jan 2016 14:24:39 GMT
+      - Wed, 13 Apr 2016 02:33:35 GMT
       Server:
       - Google Frontend
       Cache-Control:
       - private
       Alt-Svc:
-      - quic=":443"; ma=604800; v="30,29,28,27,26,25"
+      - quic=":443"; ma=2592000; v="32,31,30,29,28,27,26,25"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"response":[{"success":true,"warning":{"message":"Anomaly detected:
-        time skew. User will be excluded from analytics."}},{"isOffline":true,"success":true,"warning":{"message":"Anomaly
+      string: '{"response":[{"isOffline":true,"success":true,"warning":{"message":"Anomaly
+        detected: time skew. User will be excluded from analytics."}},{"isOffline":true,"success":true,"warning":{"message":"Anomaly
         detected: time skew. User will be excluded from analytics."}}]}'
     http_version: 
   recorded_at: Wed, 12 Aug 2015 00:00:00 GMT


### PR DESCRIPTION
As per DE-10851 users were ending up with two events sometimes, especially for registration, because a) our `eut.create_date` is a date getting turned back into a time, so it never matches leanplum's registration time but more importantly b) even if it did match, we would go ahead and post it anyways and dupe the registration event that leanplum creates for users who register on the device.

This isn't that material to our use/analysis in leanplum, but it did confuse some end users.

This PR helps to remedy that by enabling the leanplum push jobs to see if a given event already exists for a given user, in which case they can skip pushing that event to leanplum.

@rfroetscher @sgrgic 