### PR TITLE
Allow active_support versions > 3

### DIFF
--- a/leanplum_api.gemspec
+++ b/leanplum_api.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.3'
 
-  gem.add_dependency 'activesupport', '~> 3.0'
+  gem.add_dependency 'activesupport', '>= 3.0'
   gem.add_dependency 'awesome_print', '~> 1'
   gem.add_dependency 'faraday', '~> 0.9', '>= 0.9.1'
   gem.add_dependency 'faraday_middleware', '~> 0.10'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,7 @@ RSpec.configure do |config|
     end
 
     # Leanplum requires passing the time in some requests so we freeze it.
-    Timecop.freeze('2015-08-12'.to_time.utc)
+    Timecop.freeze('2015-08-12 00:00:00 UTC'.to_time.utc)
   end
 end
 


### PR DESCRIPTION
- Makes the gem Rails 4+ compatible