### PR TITLE
Allow configuring of debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,4 +125,14 @@ export LEANPLUM_API_DEBUG=true
 bundle exec whatever
 ```
 
+Alternatively you can configure the same sort of output in the gem config block:
+
+```ruby
+LeanplumApi.configure do |config|
+  config.api_debug = true
+end
+```
+
+### Developer Mode
+
 You can also configure "developer mode".  This will use the `devMode=true` parameter on some requests, which seems to sends them to a separate queue which might not count towards Leanplum's usage billing.

--- a/lib/leanplum_api/api.rb
+++ b/lib/leanplum_api/api.rb
@@ -116,7 +116,18 @@ module LeanplumApi
     end
 
     def user_attributes(user_id)
-      export_user(user_id)['userAttributes']
+      export_user(user_id)['userAttributes'].inject({}) do |attrs, (k, v)|
+        # Leanplum doesn't use true JSON for booleans...
+        if v == 'True'
+          attrs[k] = true
+        elsif v == 'False'
+          attrs[k] = false
+        else
+          attrs[k] = v
+        end
+
+        attrs
+      end
     end
 
     def user_events(user_id)

--- a/lib/leanplum_api/configuration.rb
+++ b/lib/leanplum_api/configuration.rb
@@ -23,9 +23,9 @@ module LeanplumApi
     attr_accessor :development_key
 
     # Optional
+    attr_accessor :api_debug
     attr_accessor :api_version
     attr_accessor :developer_mode
-    attr_accessor :log_path
     attr_accessor :logger
     attr_accessor :timeout_seconds
 
@@ -36,14 +36,15 @@ module LeanplumApi
     attr_accessor :s3_access_key
     attr_accessor :s3_object_prefix
 
+    # TODO Deprecated; remove in 2.0
+    attr_accessor :log_path
+
     def initialize
       @api_version = DEFAULT_LEANPLUM_API_VERSION
       @developer_mode = false
       @timeout_seconds = 600
       @logger = LeanplumApi::Logger.new(STDOUT)
-
-      # Deprecated
-      @log_path = 'log'
+      @api_debug = ENV['LEANPLUM_API_DEBUG'].to_s =~ /^(true|t|yes|y|1)$/i
     end
   end
 end

--- a/lib/leanplum_api/configuration.rb
+++ b/lib/leanplum_api/configuration.rb
@@ -36,7 +36,7 @@ module LeanplumApi
     attr_accessor :s3_access_key
     attr_accessor :s3_object_prefix
 
-    # TODO Deprecated; remove in 2.0
+    # TODO Deprecated; remove in 3.0
     attr_accessor :log_path
 
     def initialize

--- a/lib/leanplum_api/connections/production.rb
+++ b/lib/leanplum_api/connections/production.rb
@@ -43,15 +43,11 @@ module LeanplumApi::Connection
         connection.request :leanplum_response_validation
         connection.request :json
 
-        connection.response :logger, @logger, bodies: true if api_debug?
+        connection.response :logger, @logger, bodies: true if LeanplumApi.configuration.api_debug
         connection.response :json, :content_type => /\bjson$/
 
         connection.adapter Faraday.default_adapter
       end
-    end
-
-    def api_debug?
-      ENV['LEANPLUM_API_DEBUG'].to_s =~ /^(true|1)$/i
     end
 
     def authed_multi_param_string

--- a/lib/leanplum_api/version.rb
+++ b/lib/leanplum_api/version.rb
@@ -1,3 +1,3 @@
 module LeanplumApi
-  VERSION = '2.0.2'
+  VERSION = '2.1.0'
 end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -10,7 +10,8 @@ describe LeanplumApi::API do
       last_name: 'Jones',
       gender: 'm',
       email: 'still_tippin@test.com',
-      create_date: '2010-01-01'.to_date
+      create_date: '2010-01-01'.to_date,
+      is_tipping: true
     }]
   end
 
@@ -24,7 +25,8 @@ describe LeanplumApi::API do
           last_name: 'Jones',
           gender: 'm',
           email: 'still_tippin@test.com',
-          create_date: '2010-01-01'
+          create_date: '2010-01-01',
+          is_tipping: true
         )
       })
     end

--- a/spec/fixtures/vcr/export_user.yml
+++ b/spec/fixtures/vcr/export_user.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.9.2
+      - Faraday v0.10.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -22,19 +22,23 @@ http_interactions:
       - "*"
       Content-Type:
       - application/json
+      X-Cloud-Trace-Context:
+      - b7ed8a2d93f600276bf6f09eddff4c8c
+      Set-Cookie:
+      - GOOGAPPUID=xCgsIARDGByDEyKvBBQ; expires=Sun, 05-Jan-2020 06:32:36 GMT; path=/
       Date:
-      - Fri, 01 Jul 2016 14:47:49 GMT
+      - Tue, 15 Nov 2016 10:32:36 GMT
       Server:
       - Google Frontend
+      Content-Length:
+      - '303'
+      Expires:
+      - Tue, 15 Nov 2016 10:32:36 GMT
       Cache-Control:
       - private
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="34,33,32,31,30,29,28,27,26,25"
-      Transfer-Encoding:
-      - chunked
     body:
       encoding: UTF-8
-      string: '{"response":[{"created":1.43935302887E9,"events":{"purchase":{"count":11}},"lastActive":1.446709787966E9,"states":{},"success":true,"userAttributes":{"first_name":"Mike","create_date":"2010-01-01","email":"still_tippin@test.com","last_name":"Jones","gender":"m"}}]}'
+      string: '{"response":[{"totalSessions":0,"created":1.43935302887E9,"events":{"purchase":{"count":24}},"lastActive":1.446709787966E9,"states":{},"success":true,"userAttributes":{"first_name":"Mike","create_date":"2010-01-01","email":"still_tippin@test.com","last_name":"Jones","is_tipping":"True","gender":"m"}}]}'
     http_version: 
   recorded_at: Wed, 12 Aug 2015 04:00:00 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/export_user.yml
+++ b/spec/fixtures/vcr/export_user.yml
@@ -24,8 +24,6 @@ http_interactions:
       - application/json
       X-Cloud-Trace-Context:
       - b7ed8a2d93f600276bf6f09eddff4c8c
-      Set-Cookie:
-      - GOOGAPPUID=xCgsIARDGByDEyKvBBQ; expires=Sun, 05-Jan-2020 06:32:36 GMT; path=/
       Date:
       - Tue, 15 Nov 2016 10:32:36 GMT
       Server:
@@ -39,6 +37,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"response":[{"totalSessions":0,"created":1.43935302887E9,"events":{"purchase":{"count":24}},"lastActive":1.446709787966E9,"states":{},"success":true,"userAttributes":{"first_name":"Mike","create_date":"2010-01-01","email":"still_tippin@test.com","last_name":"Jones","is_tipping":"True","gender":"m"}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 12 Aug 2015 04:00:00 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/set_user_attributes.yml
+++ b/spec/fixtures/vcr/set_user_attributes.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: https://www.leanplum.com/api?action=multi&apiVersion=1.0.6&appId=<LEANPLUM_APP_ID>&clientKey=<LEANPLUM_PRODUCTION_KEY>&devMode=false&time=1439352000
     body:
       encoding: UTF-8
-      string: '{"data":[{"userId":123456,"action":"setUserAttributes","userAttributes":{"first_name":"Mike","last_name":"Jones","gender":"m","email":"still_tippin@test.com","create_date":"2010-01-01"}}]}'
+      string: '{"data":[{"userId":123456,"action":"setUserAttributes","userAttributes":{"first_name":"Mike","last_name":"Jones","gender":"m","email":"still_tippin@test.com","create_date":"2010-01-01","is_tipping":true}}]}'
     headers:
       User-Agent:
-      - Faraday v0.9.2
+      - Faraday v0.10.0
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -24,16 +24,20 @@ http_interactions:
       - "*"
       Content-Type:
       - application/json
+      X-Cloud-Trace-Context:
+      - be84cbe23b33980fe7159ca706386efb
+      Set-Cookie:
+      - GOOGAPPUID=xCgsIARDNASC7xqvBBQ; expires=Sun, 05-Jan-2020 06:28:11 GMT; path=/
       Date:
-      - Fri, 01 Jul 2016 14:47:49 GMT
+      - Tue, 15 Nov 2016 10:28:11 GMT
       Server:
       - Google Frontend
+      Content-Length:
+      - '122'
+      Expires:
+      - Tue, 15 Nov 2016 10:28:11 GMT
       Cache-Control:
       - private
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="34,33,32,31,30,29,28,27,26,25"
-      Transfer-Encoding:
-      - chunked
     body:
       encoding: UTF-8
       string: '{"response":[{"success":true,"warning":{"message":"Anomaly detected:

--- a/spec/fixtures/vcr/set_user_attributes.yml
+++ b/spec/fixtures/vcr/set_user_attributes.yml
@@ -26,8 +26,6 @@ http_interactions:
       - application/json
       X-Cloud-Trace-Context:
       - be84cbe23b33980fe7159ca706386efb
-      Set-Cookie:
-      - GOOGAPPUID=xCgsIARDNASC7xqvBBQ; expires=Sun, 05-Jan-2020 06:28:11 GMT; path=/
       Date:
       - Tue, 15 Nov 2016 10:28:11 GMT
       Server:
@@ -42,6 +40,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"response":[{"success":true,"warning":{"message":"Anomaly detected:
         time skew. User will be excluded from analytics."}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 12 Aug 2015 04:00:00 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/track_events_and_attributes.yml
+++ b/spec/fixtures/vcr/track_events_and_attributes.yml
@@ -27,8 +27,6 @@ http_interactions:
       - application/json
       X-Cloud-Trace-Context:
       - 4a5e92e1cf1088dd41b9caa898272564
-      Set-Cookie:
-      - GOOGAPPUID=xCgsIARCqBiCZx6vBBQ; expires=Sun, 05-Jan-2020 06:29:45 GMT; path=/
       Date:
       - Tue, 15 Nov 2016 10:29:45 GMT
       Server:
@@ -45,6 +43,6 @@ http_interactions:
         time skew. User will be excluded from analytics."}},{"isOffline":true,"success":true,"warning":{"message":"Anomaly
         detected: time skew. User will be excluded from analytics."}},{"isOffline":true,"success":true,"warning":{"message":"Anomaly
         detected: time skew. User will be excluded from analytics."}}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 12 Aug 2015 04:00:00 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/track_events_and_attributes.yml
+++ b/spec/fixtures/vcr/track_events_and_attributes.yml
@@ -5,11 +5,11 @@ http_interactions:
     uri: https://www.leanplum.com/api?action=multi&apiVersion=1.0.6&appId=<LEANPLUM_APP_ID>&clientKey=<LEANPLUM_PRODUCTION_KEY>&devMode=false&time=1439352000
     body:
       encoding: UTF-8
-      string: '{"data":[{"userId":123456,"action":"setUserAttributes","userAttributes":{"first_name":"Mike","last_name":"Jones","gender":"m","email":"still_tippin@test.com","create_date":"2010-01-01"}},{"action":"track","event":"purchase","userId":123456,"time":"1439352000","params":{"some_timestamp":"2015-05-01
+      string: '{"data":[{"userId":123456,"action":"setUserAttributes","userAttributes":{"first_name":"Mike","last_name":"Jones","gender":"m","email":"still_tippin@test.com","create_date":"2010-01-01","is_tipping":true}},{"action":"track","event":"purchase","userId":123456,"time":"1439352000","params":{"some_timestamp":"2015-05-01
         01:02:03"}},{"action":"track","event":"purchase_page_view","userId":54321,"time":"1439351400"}]}'
     headers:
       User-Agent:
-      - Faraday v0.9.2
+      - Faraday v0.10.0
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,16 +25,20 @@ http_interactions:
       - "*"
       Content-Type:
       - application/json
+      X-Cloud-Trace-Context:
+      - 4a5e92e1cf1088dd41b9caa898272564
+      Set-Cookie:
+      - GOOGAPPUID=xCgsIARCqBiCZx6vBBQ; expires=Sun, 05-Jan-2020 06:29:45 GMT; path=/
       Date:
-      - Fri, 01 Jul 2016 14:47:51 GMT
+      - Tue, 15 Nov 2016 10:29:45 GMT
       Server:
       - Google Frontend
+      Content-Length:
+      - '372'
+      Expires:
+      - Tue, 15 Nov 2016 10:29:45 GMT
       Cache-Control:
       - private
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="34,33,32,31,30,29,28,27,26,25"
-      Transfer-Encoding:
-      - chunked
     body:
       encoding: UTF-8
       string: '{"response":[{"success":true,"warning":{"message":"Anomaly detected:


### PR DESCRIPTION
Our leanplum resurrection events seem to be getting lost; I want to be able to just turn on full logging without adding ENV variables to the `dw_runner` calls because `dw_runner` makes that really annoying.