### PR TITLE
Remove unnecessary .to_json call in Faraday middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,21 @@
+## HEAD
+* Remove useless `.to_json` call in Faraday middleware
+
 ## 4.0.1
 * Slight improvement to `ResponseValidation` readability; slight change to error messages
 
 ## 4.0.0
 * **BREAKING CHANGE** - `track_multi` method signature has changed.
 * **BREAKING CHANGE** - Data export methods moved to the `DataExportAPI` class
-* *New Feature* - Added support for setDeviceAttributes (thanks @beingmattlevy)
+* **BREAKING CHANGE** - rename `wait_for_job` to `wait_for_export_job`
+* *New Feature* - Added support for `setDeviceAttributes` (thanks @beingmattlevy)
 * Fix `export_users`
 
 ## 3.1.0
 * Add the ability to send events as `userAttributes` properties
 
 ## 3.0.3
-* Single connection class; rename `wait_for_job` to `wait_for_export_job`
+* Single connection class; deprecate `wait_for_job` in favor of `wait_for_export_job`
 
 ## 3.0.2
 * Leanplum changed their "Anomalous timestamp" message again, so now we're just going to reset everyone on any type of warning

--- a/lib/leanplum_api/faraday_middleware/response_validation.rb
+++ b/lib/leanplum_api/faraday_middleware/response_validation.rb
@@ -9,9 +9,8 @@ module LeanplumApi
     WARN = 'warning'.freeze
 
     def call(environment)
-      if environment.body
-        requests = environment.body[:data] if environment.body[:data] && environment.body[:data].is_a?(Array)
-        environment.body = environment.body.to_json
+      if environment.body && environment.body[:data] && environment.body[:data].is_a?(Array)
+        requests = environment.body[:data]
       end
 
       @app.call(environment).on_complete do |response|


### PR DESCRIPTION
Pretty sure this is covered by https://github.com/lumoslabs/leanplum_api/blob/master/lib/leanplum_api/connection.rb#L43 - but either way it makes no difference in terms of making requests (specs and VCR recordings are 100% the same without).

i don't think this is enough of a change to warrant a release so i'm just putting the change on master, but we could also release it.