### PR TITLE
add currencyCode and value to event's parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ api.set_user_attributes(user_attributes)
 event = {
   user_id: 12345,
   event: 'purchase',
+  currency_code: 'USD', # ISO 4217 currency code
+  value: 10.0,
   time: Time.now.utc, # Event timestamps will be converted to epoch seconds
   info: 'reallybigpurchase',
   some_event_property: 'boss_hog_on_candy'

--- a/lib/leanplum_api/api.rb
+++ b/lib/leanplum_api/api.rb
@@ -175,6 +175,8 @@ module LeanplumApi
       event = { action: TRACK, event: event_name }.merge(extract_user_id_or_device_id_hash!(event_hash))
       event.merge!(time: event_hash.delete(:time).strftime('%s').to_i) if event_hash[:time]
       event.merge!(info: event_hash.delete(:info)) if event_hash[:info]
+      event.merge!(currencyCode: event_hash.delete(:currency_code)) if event_hash[:currency_code]
+      event.merge!(value: event_hash.delete(:value).to_f) if event_hash[:value]
       event.merge!(allowOffline: true) if options[:allow_offline]
 
       event_hash.keys.size > 0 ? event.merge(params: event_hash.symbolize_keys ) : event

--- a/lib/leanplum_api/version.rb
+++ b/lib/leanplum_api/version.rb
@@ -1,3 +1,3 @@
 module LeanplumApi
-  VERSION = '4.1.0'.freeze
+  VERSION = '4.2.0'.freeze
 end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -180,13 +180,17 @@ describe LeanplumApi::API do
   context 'event tracking' do
     let(:timestamp) { '2015-05-01 01:02:03' }
     let(:purchase) { 'purchase' }
+    let(:currency_code) { 'USD' }
+    let(:purchase_value) { 10.0 }
     let(:events) do
       [
         {
           user_id: first_user_id,
           event: purchase,
           time: last_event_time,
-          some_timestamp: timestamp
+          some_timestamp: timestamp,
+          currency_code: 'USD',
+          value: 10.0
         },
         {
           user_id: 54321,
@@ -201,6 +205,8 @@ describe LeanplumApi::API do
         {
           userId: first_user_id,
           event: purchase,
+          currencyCode: currency_code,
+          value: purchase_value,
           time: last_event_time.strftime('%s').to_i,
           action: described_class::TRACK,
           params: { some_timestamp: timestamp }


### PR DESCRIPTION
[Leanplum API doc](https://www.leanplum.com/docs/api/production#track)

Hey, I found it would be nice to add `currencyCode` and `value` to the purchase event.
Leanplum will automatically convert the value into your preferred currency.

If the `currencyCode` and `value` added to the event, you can see the value of the user purchase in Leanplum dashboard.

<img width="505" alt="2018-02-24 10 50 12" src="https://user-images.githubusercontent.com/2809616/36632062-4f7fddf2-19bc-11e8-95bc-c8329aab619c.png">
