### PR TITLE
Set fullErasure default on delete_user

### DIFF
--- a/lib/leanplum_api/api.rb
+++ b/lib/leanplum_api/api.rb
@@ -84,8 +84,8 @@ module LeanplumApi
       production_connection.get(action: 'getVars', userId: user_id).first['vars']
     end
 
-    def delete_user(user_id)
-      development_connection.get(action: 'deleteUser', userId: user_id).first['vars']
+    def delete_user(user_id, full_erasure = false)
+      development_connection.get(action: 'deleteUser', userId: user_id, fullErasure: full_erasure).first['vars']
     end
 
     # If you pass old events OR users with old date attributes (e.g. create_date for an old user), Leanplum


### PR DESCRIPTION
[Leanplum Api doc](https://docs.leanplum.com/reference#post_api-action-deleteuser
)
Hey, according to GDPR policy, I found it would be nice to set `fullErasure ` default on `delete_user`.
When set `fullErasure` to true, leanplum will deletes all session and analytics data for the selected user but it may take up to 15 days to process fully.